### PR TITLE
more robust clean up before submitting spark job

### DIFF
--- a/spark/submit_job.sh
+++ b/spark/submit_job.sh
@@ -32,7 +32,12 @@ KUBERNETES_MASTER=k8s://https://35.184.11.111 # should be a map with staging/pro
 # clean up old job of the same name
 # WARNING this grep is not smart, it will remove all jobs that contain JOB_NAME. This means
 # we do currently support having a job named `facebook-ads` alongside `facebook-ads-metrics`
+echo $JOB_NAME
+echo 1
+kubectl get pods
+echo 2
 kubectl delete pod $(kubectl get pods -a | grep ${JOB_NAME} | awk '{print $1}')
+echo 3
 
 echo 'starting spark job'
 $SPARK_HOME/bin/spark-submit \

--- a/spark/submit_job.sh
+++ b/spark/submit_job.sh
@@ -29,9 +29,7 @@ gcloud container clusters get-credentials $CLUSTER
 IMAGE_TAG=${CI_COMMIT_ID}
 KUBERNETES_MASTER=k8s://https://35.184.11.111 # should be a map with staging/production keys
 
-# clean up old job of the same name
-# WARNING this grep is not smart, it will remove all jobs that contain JOB_NAME. This means
-# we do currently support having a job named `facebook-ads` alongside `facebook-ads-metrics`
+# clean up old job with same label
 pods=$(kubectl get pods -a -l jobName=${JOB_NAME} | awk '{print $1}')
 if [[ $pods ]]; then
   kubectl delete pod $pods


### PR DESCRIPTION
* spark_submit use pod labels
* use pod labels when trying to delete spark jobs that already exist
* check if pods exist before trying to delete them